### PR TITLE
Settings to enable switching between block-by-block and filter modes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,15 +114,20 @@ Usage
     You can also set the optional ``ETHEREUM_LOGS_BATCH_SIZE`` setting which limits the maximum amount of the blocks that can be read at a time from the celery task.
 
 
-*******************
-Using event filters
-*******************
+***************
+Operation modes
+***************
 
-If your Ethereum Node supports log filters, you can activate it in the Django settings and it will use filters instead of iterating thru all blocks and all transactions.
+The event listener can operate in different modes:
+
+* `blocks`: this is the default mode, and goes block by block and tx by tx fetching the receipts and searching for logs matching the monitored ones.
+* `filters`: this uses `web3.eth.filter` to search each of the monitored events in the range.
+* `auto`: in this mode, the listener choose automatically wether to use `blocks` mode or `filters` mode, by checking if the number of blocks to process exceeds a given threshold (`ETHEREUM_LOGS_AUTO_THRESHOLD`, default 5000). If exceeds that threshold, uses `filters` mode, otherwise, uses `blocks` mode.
+
 
     .. code-block:: python
 
-        ETHEREUM_LOGS_FILTER_AVAILABLE = True
+        ETHEREUM_LOGS_MODE = "blocks"
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -120,14 +120,15 @@ Operation modes
 
 The event listener can operate in different modes:
 
-* `blocks`: this is the default mode, and goes block by block and tx by tx fetching the receipts and searching for logs matching the monitored ones.
-* `filters`: this uses `web3.eth.filter` to search each of the monitored events in the range.
-* `auto`: in this mode, the listener choose automatically wether to use `blocks` mode or `filters` mode, by checking if the number of blocks to process exceeds a given threshold (`ETHEREUM_LOGS_AUTO_THRESHOLD`, default 5000). If exceeds that threshold, uses `filters` mode, otherwise, uses `blocks` mode.
+* ``blocks``: this is the default mode, and goes block by block and tx by tx fetching the receipts and searching for logs matching the monitored ones.
+* ``filters``: this uses ``web3.eth.filter`` to search each of the monitored events in the range.
+* ``auto``:  in this mode, the listener automatically chooses whether to use ``blocks`` mode or ``filters`` mode, by checking if the number of blocks to process exceeds a given threshold (``ETHEREUM_LOGS_AUTO_THRESHOLD``, default 5000). If it exceeds that threshold, it uses ``filters`` mode, otherwise, it uses ``blocks`` mode.
 
 
     .. code-block:: python
 
-        ETHEREUM_LOGS_MODE = "blocks"
+        ETHEREUM_LOGS_MODE = "auto"
+        ETHEREUM_LOGS_AUTO_THRESHOLD = 500
 
 
 

--- a/django_ethereum_events/event_listener.py
+++ b/django_ethereum_events/event_listener.py
@@ -157,9 +157,9 @@ class EventListener:
             mode = "blocks" if (end - start) <= threshold else "filters"
 
         if mode == "filters":
-            self._execute_using_filters()
+            self._execute_using_filters(start, end)
         else:
-            self._execute_iterating_all_blocks()
+            self._execute_iterating_all_blocks(start, end)
 
     def _execute_using_filters(self, start, end):
         """Uses filters to fetch required logs"""

--- a/django_ethereum_events/event_listener.py
+++ b/django_ethereum_events/event_listener.py
@@ -151,12 +151,12 @@ class EventListener:
 
         mode = mode or getattr(settings, "ETHEREUM_LOGS_MODE", None)
         if mode is None:
-            mode = "filters" if getattr(settings, "ETHEREUM_LOGS_FILTER_AVAILABLE", False) else "all_blocks"
+            mode = "filters" if getattr(settings, "ETHEREUM_LOGS_FILTER_AVAILABLE", False) else "blocks"
         elif mode == "auto":
             threshold = getattr(settings, "ETHEREUM_LOGS_AUTO_THRESHOLD", 5000)
-            mode = "all_blocks" if (end - start) <= threshold else "filters"
+            mode = "blocks" if (end - start) <= threshold else "filters"
 
-        if getattr(settings, "ETHEREUM_LOGS_FILTER_AVAILABLE", False):
+        if mode == "filters":
             self._execute_using_filters()
         else:
             self._execute_iterating_all_blocks()

--- a/django_ethereum_events/event_listener.py
+++ b/django_ethereum_events/event_listener.py
@@ -33,7 +33,7 @@ class EventListener:
 
         return None, None
 
-    def get_pending_blocks(self):
+    def get_pending_blocks(self, start=None, end=None):
         """
         Retrieve the blocks that have not been processed.
 
@@ -42,7 +42,8 @@ class EventListener:
             the unprocessed block numbers.
 
         """
-        start, end = self._get_block_range()
+        if start is None and end is None:
+            start, end = self._get_block_range()
         if start is None:
             return []
         else:
@@ -139,18 +140,26 @@ class EventListener:
             self.decoder.refresh_state(block_number=block_number)
             refresh_cache_update_value(update_required=False)
 
-    def execute(self):
+    def execute(self, mode=None):
         """Program loop, does all the underlying work."""
+        start, end = self._get_block_range()
+        if start is None:
+            return
+
+        mode = mode or getattr(settings, "ETHEREUM_LOGS_MODE", None)
+        if mode is None:
+            mode = "filters" if getattr(settings, "ETHEREUM_LOGS_FILTER_AVAILABLE", False) else "all_blocks"
+        elif mode == "auto":
+            threshold = getattr(settings, "ETHEREUM_LOGS_AUTO_THRESHOLD", 5000)
+            mode = "all_blocks" if (end - start) <= threshold else "filters"
+
         if getattr(settings, "ETHEREUM_LOGS_FILTER_AVAILABLE", False):
             self._execute_using_filters()
         else:
             self._execute_iterating_all_blocks()
 
-    def _execute_using_filters(self):
+    def _execute_using_filters(self, start, end):
         """Uses filters to fetch required logs"""
-        start, end = self._get_block_range()
-        if start is None:
-            return
         all_logs = []
 
         for (address, topic) in self.decoder.monitored_events.keys():
@@ -160,16 +169,18 @@ class EventListener:
                 "fromBlock": start,
                 "toBlock": end,
             })
-            all_logs.extend(log_filter.get_all_entries())
+            all_logs.extend(
+                [evt for evt in log_filter.get_all_entries() if not evt.get("removed", False)]
+            )
 
         all_logs.sort(key=lambda log: (log["blockNumber"], log["logIndex"]))
         decoded_logs = self.decoder.decode_logs(all_logs)
         self.save_events(decoded_logs)
         self.update_block_number(end)
 
-    def _execute_iterating_all_blocks(self):
+    def _execute_iterating_all_blocks(self, start, end):
         """Executes iterating thru all blocks and txs"""
-        pending_blocks = self.get_pending_blocks()
+        pending_blocks = self.get_pending_blocks(start, end)
         for block in pending_blocks:
             self.check_for_state_updates(block)
             logs = self.get_block_logs(block)

--- a/django_ethereum_events/event_listener.py
+++ b/django_ethereum_events/event_listener.py
@@ -27,6 +27,9 @@ class EventListener:
     def _get_block_range(self):
         current = self.web3.eth.blockNumber
         step = getattr(settings, "ETHEREUM_LOGS_BATCH_SIZE", 10000)
+        stay_behind = getattr(settings, "ETHEREUM_LOGS_STAY_BEHIND_BLOCKS", None)
+        if stay_behind:
+            current -= stay_behind
         if self.daemon.block_number < current:
             start = self.daemon.block_number + 1
             return start, min(current, start + step)


### PR DESCRIPTION
- Adds a new setting, `ETHEREUM_LOGS_MODE` that can take three values:
  - `blocks`: iterates block by block, tx by tx, fetching the transaction receipt and getting the logs.
  - `filters`: uses filters to find the events
  - `auto`: if blocks to process is less than `ETHEREUM_LOGS_AUTO_THRESHOLD` (default 5000), uses `blocks` mode, otherwise, uses `filters` mode

- Fix in the filters mode, to script events tagged as removed. 
- `ETHEREUM_LOGS_STAY_BEHIND_BLOCKS` setting to operate always a few blocks behind the last one, to avoid reorgs or fork errors. Disabled by default.
